### PR TITLE
[US-15] Complete dev environment inside the docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-# Docker for the project
+# Usage
 
-Step 1 - Create the MySQL database container
+## With only the docker-compose.yml 
+
+```bash
+docker-compose up
+```
+
+## With the Dockerfile
+
+Step 1 - Create the MySQL database container (just for the first time)
 
 ```bash
 # For Linux use $PWD instead of ${PWD}
-docker run -p 3306:3306 --name mysql-server -v mysql-v:/var/lib/mysql -v ${PWD}/mysql:/docker-entrypoint-initdb.d -e MYSQL_ROOT_PASSWORD=root -d mysql
+docker run -p 3306:3306 --name jokr-mysql-server -v mysql-v:/var/lib/mysql -v ${PWD}/mysql:/docker-entrypoint-initdb.d -e MYSQL_ROOT_PASSWORD=root -d mysql
 ```
 
-Step 2 - Build the image to run the web page server
+Step 2 - Create the image that builds the project and runs it
 
 ```bash
-docker build -t spring-app-img .
+docker build -t jokr-app-img .
 ```
 
-Step 3 - Run the previous image
+Step 3 - Run the previous image with a link to the database and the correct host to it
 
 ```bash
-docker run --rm -it -p 8080:8080 --link mysql-server -e DATABASE_HOST=mysql-server spring-app-img
+docker run --rm -it -p 8080:8080 --link jokr-mysql-server -e DATABASE_HOST=jokr-mysql-server jokr-app-img
 ```
 
-# Resources
-
-https://spring.io/guides/gs/spring-boot-docker/
-
-https://spring.io/guides/gs/accessing-data-mysql/
-
-https://spring.io/blog/2018/11/08/spring-boot-in-a-container
-
-https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
+Each time a change is done just run the 2nd and 3rd Step again, making sure that the MySQL continer is started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-version: '3.1'
+version: '3.8'
 services:
-  myapp-mysql:
+  ecomm-mysql:
     image: mysql
     ports:
       - 3306:3306
@@ -9,27 +9,33 @@ services:
       - ./mysql:/docker-entrypoint-initdb.d
     environment:
       - MYSQL_ROOT_PASSWORD=root
+    security_opt:
+    - seccomp:unconfined
     networks:
-      - mysql-network
+      - ecomm-network
 
-  myapp-main:
-    build: .
+  ecomm-main:
+    image: openjdk:11
+    depends_on:
+      - ecomm-mysql
+    working_dir: /work
+    volumes:
+      - ./:/work
+    entrypoint: ["/bin/bash", "-c" , "./mvnw dependency:go-offline && ./mvnw install && java -jar target/app.jar"]
     ports:
       - 8080:8080
-    restart: on-failure
-    depends_on:
-      - myapp-mysql
+    # restart: on-failure
     environment:
-      - DATABASE_HOST=myapp-mysql
+      - DATABASE_HOST=ecomm-mysql
       - DATABASE_USER=springuser
       - DATABASE_PASSWORD=MySQL-P
       - DATABASE_NAME=db_example
       - DATABASE_PORT=3306
     networks:
-      - mysql-network
+      - ecomm-network
 
 networks:
-  mysql-network:
+  ecomm-network:
 
 volumes:
   mysql-v:

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 		</dependency>
 	</dependencies>
 	<build>
+		<finalName>app</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## What?
The main changes went to the docker-compose file, to have a better way to run the app completely in Docker, now instead of going through 3 commands, the only thing we need is to run just 1 command and the README.md has the new instructions for the task.

## Why?
Make a way to test the app on Docker easier for the development team and to prepare a future docker-compose file that can run all the projects in one command on the cloud.

## Testing / Proof
Both containers running using docker-compose up
![image](https://user-images.githubusercontent.com/44516996/141193327-7b0fe424-4331-4e88-80d4-65a152a7a1b0.png)


## How can this change be undone in case of failure?
One thing to do is to run the previous 3 steps, the option is still there, now the docker-compose helps to make all of that more simple.

ping @fullstack-bootcamp-2021