### PR TITLE
[US-33] Docker build and push on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             docker push $IMAGE_NAME:latest
 workflows:
   version: 2
-  build-then-test:
+  app-docker-push:
     jobs:
       - build
       - test:
@@ -93,12 +93,12 @@ workflows:
       - docker-build:
           requires:
             - test
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - publish-latest:
           requires:
             - docker-build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 executors:
   docker-publisher:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.0
-
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: pacodevs/jokr
+    docker:
+      - image: circleci/buildpack-deps:stretch
 jobs:
   build:
     docker:
@@ -19,7 +24,6 @@ jobs:
          root: ./
          paths:
            - target/
-
   test:
     docker:
       - image: circleci/openjdk:11
@@ -48,7 +52,36 @@ jobs:
       - attach_workspace:
           at: ./target
       - run: ./mvnw test
-
+  docker-build:
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t $IMAGE_NAME:latest .
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
+  publish-latest:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push $IMAGE_NAME:latest
 workflows:
   version: 2
   build-then-test:
@@ -57,3 +90,15 @@ workflows:
       - test:
           requires:
             - build
+      - docker-build:
+          requires:
+            - test
+          # filters:
+          #   branches:
+          #     only: master
+      - publish-latest:
+          requires:
+            - docker-build
+          # filters:
+          #   branches:
+          #     only: master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,9 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
     security_opt:
-    - seccomp:unconfined
+      - seccomp:unconfined
     networks:
       - ecomm-network
-
   ecomm-main:
     image: openjdk:11
     depends_on:
@@ -21,7 +20,14 @@ services:
     working_dir: /work
     volumes:
       - ./:/work
-    entrypoint: ["/bin/bash", "-c" , "./mvnw dependency:go-offline && ./mvnw install && java -jar target/app.jar"]
+    # Change to "./mvnw install -DskipTests" to skip tests
+    entrypoint:
+      [
+        "/bin/bash",
+        "-c",
+        "./mvnw dependency:go-offline && ./mvnw install && java -jar
+          target/app.jar"
+      ]
     ports:
       - 8080:8080
     # restart: on-failure
@@ -33,10 +39,8 @@ services:
       - DATABASE_PORT=3306
     networks:
       - ecomm-network
-
 networks:
-  ecomm-network:
-
+  ecomm-network: null
 volumes:
   mysql-v:
     external: false


### PR DESCRIPTION
## What?
Now CircleCI has the ability to build and push a docker image to a public registry, in this case to Docker Hub.

## Why?
To enable the next step that is Continuous Delivery for both projects based on images from the master branch.

## Testing / Proof
Proof of the docker image published on docker hub.
![image](https://user-images.githubusercontent.com/44516996/143503358-b7a5e5ea-8137-4819-a8bd-43af3cead320.png)

## How can this change be undone in case of failure?
Remove the added lines on the .circleci/config.yml to avoid building and pushing the new docker image.

ping @fullstack-bootcamp-2021
