### PR TITLE
[US-40] Fix for compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Step 1 - Create the MySQL database container (just for the first time)
 
 ```bash
 # For Linux use $PWD instead of ${PWD}
-docker run -p 3306:3306 --name jokr-mysql-server -v mysql-v:/var/lib/mysql -v ${PWD}/mysql:/docker-entrypoint-initdb.d -e MYSQL_ROOT_PASSWORD=root -d mysql:8.0
+docker run -p 3306:3306 --name jokr-mysql-server -v mysql-v:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=springuser -e MYSQL_PASSWORD=MySQL-P -e MYSQL_DATABASE=jokr_db -d mysql:8.0
 ```
 
 Step 2 - Create the image that builds the project and runs it

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,9 +6,11 @@ services:
       - 3306:3306
     volumes:
       - mysql-v:/var/lib/mysql
-      - ./mysql:/docker-entrypoint-initdb.d
     environment:
-      - MYSQL_ROOT_PASSWORD=root
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: springuser
+      MYSQL_PASSWORD: MySQL-P
+      MYSQL_DATABASE: jokr_db
     security_opt:
       - seccomp:unconfined
     networks:
@@ -25,18 +27,21 @@ services:
       [
         "/bin/sh",
         "-c",
-        "./mvnw dependency:go-offline --no-transfer-progress && ./mvnw install --no-transfer-progress -DskipTests && java
-          -jar target/app.jar"
+        "wget -qO-
+          https://raw.githubusercontent.com/eficode/wait-for/v2.2.0/wait-for |
+          sh -s -- ecomm-mysql:3306 -- echo DB ready && ./mvnw
+          dependency:go-offline --no-transfer-progress && ./mvnw install
+          --no-transfer-progress -DskipTests && java -jar target/app.jar"
       ]
     ports:
       - 8080:8080
     # restart: on-failure
     environment:
-      - DATABASE_HOST=ecomm-mysql
-      - DATABASE_USER=springuser
-      - DATABASE_PASSWORD=MySQL-P
-      - DATABASE_NAME=jokr_db
-      - DATABASE_PORT=3306
+      DATABASE_HOST: ecomm-mysql
+      DATABASE_USER: springuser
+      DATABASE_PASSWORD: MySQL-P
+      DATABASE_NAME: jokr_db
+      DATABASE_PORT: 3306
     networks:
       - ecomm-network
   ecomm-front:

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -6,9 +6,11 @@ services:
       - 3306:3306
     volumes:
       - mysql-v:/var/lib/mysql
-      - ./mysql:/docker-entrypoint-initdb.d
     environment:
-      - MYSQL_ROOT_PASSWORD=root
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: springuser
+      MYSQL_PASSWORD: MySQL-P
+      MYSQL_DATABASE: jokr_db
     security_opt:
       - seccomp:unconfined
     networks:
@@ -25,18 +27,21 @@ services:
       [
         "/bin/sh",
         "-c",
-        "./mvnw dependency:go-offline && ./mvnw install && java -jar
-          target/app.jar"
+        "wget -qO-
+          https://raw.githubusercontent.com/eficode/wait-for/v2.2.0/wait-for |
+          sh -s -- ecomm-mysql:3306 -- echo DB ready && ./mvnw
+          dependency:go-offline --no-transfer-progress && ./mvnw install
+          --no-transfer-progress && java -jar target/app.jar"
       ]
     ports:
       - 8080:8080
     # restart: on-failure
     environment:
-      - DATABASE_HOST=ecomm-mysql
-      - DATABASE_USER=springuser
-      - DATABASE_PASSWORD=MySQL-P
-      - DATABASE_NAME=jokr_db
-      - DATABASE_PORT=3306
+      DATABASE_HOST: ecomm-mysql
+      DATABASE_USER: springuser
+      DATABASE_PASSWORD: MySQL-P
+      DATABASE_NAME: jokr_db
+      DATABASE_PORT: 3306
     networks:
       - ecomm-network
   ecomm-front:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@ services:
       - 3306:3306
     volumes:
       - mysql-v:/var/lib/mysql
-      - ./mysql:/docker-entrypoint-initdb.d
     environment:
-      - MYSQL_ROOT_PASSWORD=root
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: springuser
+      MYSQL_PASSWORD: MySQL-P
+      MYSQL_DATABASE: jokr_db
     security_opt:
       - seccomp:unconfined
     networks:
@@ -25,18 +27,21 @@ services:
       [
         "/bin/sh",
         "-c",
-        "./mvnw dependency:go-offline --no-transfer-progress && ./mvnw install --no-transfer-progress -DskipTests && java
-          -jar target/app.jar"
+        "wget -qO-
+          https://raw.githubusercontent.com/eficode/wait-for/v2.2.0/wait-for |
+          sh -s -- ecomm-mysql:3306 -- echo DB ready && ./mvnw
+          dependency:go-offline --no-transfer-progress && ./mvnw install
+          --no-transfer-progress -DskipTests && java -jar target/app.jar"
       ]
     ports:
       - 8080:8080
     # restart: on-failure
     environment:
-      - DATABASE_HOST=ecomm-mysql
-      - DATABASE_USER=springuser
-      - DATABASE_PASSWORD=MySQL-P
-      - DATABASE_NAME=jokr_db
-      - DATABASE_PORT=3306
+      DATABASE_HOST: ecomm-mysql
+      DATABASE_USER: springuser
+      DATABASE_PASSWORD: MySQL-P
+      DATABASE_NAME: jokr_db
+      DATABASE_PORT: 3306
     networks:
       - ecomm-network
   ecomm-front:

--- a/mysql/startup.sql
+++ b/mysql/startup.sql
@@ -1,3 +1,0 @@
-CREATE DATABASE jokr_db;
-CREATE user 'springuser'@'%' identified BY 'MySQL-P';
-GRANT all ON jokr_db.* TO 'springuser'@'%';


### PR DESCRIPTION
## What?
A quick change to run all docker-compose files waiting for the DB to start and a new way to create it.

## Why?
To establish a standard to run all docker-compose files across the front and back projects.

## Testing / Proof
The whole app works by using "docker-compose up".
![image](https://user-images.githubusercontent.com/44516996/144688738-cfb1d9ac-acc0-42af-84db-b0e48ba03a49.png)
![image](https://user-images.githubusercontent.com/44516996/144688683-11c1d75a-6e1a-429e-8d0b-b2202970e8d1.png)

## How can this change be undone in case of failure?
Go back to previous versions of the docker-compose environments.

ping @fullstack-bootcamp-2021
