### PR TITLE
[US-42] Heroku deploy on merge from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,14 @@ jobs:
           command: docker load -i /tmp/workspace/image.tar
       - run:
           name: Tag image for Heroku push
-          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:release
+          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:latest
       - run:
           name: Push Docker image to Heroku
           command: |
             set -x
             sudo curl https://cli-assets.heroku.com/install.sh | sh
             HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
-            docker push $HEROKU_IMAGE:release
+            docker push $HEROKU_IMAGE:latest
             HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-back web
 executors:
   docker-publisher:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,18 +114,18 @@ workflows:
       - docker-build:
           requires:
             - test
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - publish-latest:
           requires:
             - docker-build
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - heroku-release:
           requires:
             - publish-latest
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,4 @@
 version: 2.1
-executors:
-  docker-publisher:
-    environment:
-      IMAGE_NAME: pacodevs/jokr
-    docker:
-      - image: circleci/buildpack-deps:stretch
 jobs:
   build:
     docker:
@@ -82,6 +76,33 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push $IMAGE_NAME:latest
+  heroku-release:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Tag image for Heroku push
+          command: docker tag $IMAGE_NAME:latest $HEROKU_IMAGE:release
+      - run:
+          name: Push Docker image to Heroku
+          command: |
+            set -x
+            sudo curl https://cli-assets.heroku.com/install.sh | sh
+            HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:login
+            docker push $HEROKU_IMAGE:release
+            HEROKU_API_KEY=${HEROKU_API_KEY} heroku container:release -a jokr-back web
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: pacodevs/jokr
+      HEROKU_IMAGE: registry.heroku.com/jokr-back/web
+    docker:
+      - image: circleci/buildpack-deps:stretch
 workflows:
   version: 2
   app-docker-push:
@@ -93,12 +114,18 @@ workflows:
       - docker-build:
           requires:
             - test
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - publish-latest:
           requires:
             - docker-build
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
+      - heroku-release:
+          requires:
+            - publish-latest
+          # filters:
+          #   branches:
+          #     only: master

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,5 @@ spring.datasource.username=${DATABASE_USER:springuser}
 spring.datasource.password=${DATABASE_PASSWORD:MySQL-P}
 spring.datasource.driver-class-name=${DB_DRIVER:com.mysql.jdbc.Driver}
 #spring.jpa.show-sql: true
-# server.port=8080
+server.port=${PORT:8080}
 spring.jackson.serialization.fail-on-empty-beans=false
-
-
-


### PR DESCRIPTION
## What?
Changes on the .circleci/config.yml file to allow CircleCI to send a docker image built from a Dockerfile to be deployed after each PR is accepted and a merge to master is ready.

## Why?
To start the CD cycle within both projects, by first hosting both apps separately and then bringing them together.

## Testing / Proof
Screenshot of how the back-end app is working on Heroku together with a DB.
![image](https://user-images.githubusercontent.com/44516996/145247769-854a08fb-5f13-4a11-a211-25dcd9935938.png)

## How can this change be undone in case of failure?
Remove the last job in the .circleci/config.yml file going back to only push the image to docker hub.

ping @fullstack-bootcamp-2021
