### PR TITLE
[US-42] Connection with the Heroku Front App

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN ./mvnw dependency:go-offline
 COPY . /work/
 RUN ./mvnw install -DskipTests
 
-ENTRYPOINT ["java","-jar","/work/target/app.jar"]
+ENTRYPOINT ["java", "-jar", "/work/target/app.jar"]

--- a/src/main/java/apex/ingagers/ecommerce/config/SpringFoxConfig.java
+++ b/src/main/java/apex/ingagers/ecommerce/config/SpringFoxConfig.java
@@ -12,7 +12,6 @@ import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-// @Profile({"!prod && dev"})
 @EnableSwagger2
 public class SpringFoxConfig {
     @Value("${documentation.enabled}")

--- a/src/main/java/apex/ingagers/ecommerce/config/SpringFoxConfig.java
+++ b/src/main/java/apex/ingagers/ecommerce/config/SpringFoxConfig.java
@@ -1,7 +1,9 @@
 package apex.ingagers.ecommerce.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+// import org.springframework.context.annotation.Profile;
 
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -9,14 +11,20 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-@Configuration @EnableSwagger2
-public class SpringFoxConfig {                                    
+@Configuration
+// @Profile({"!prod && dev"})
+@EnableSwagger2
+public class SpringFoxConfig {
+    @Value("${documentation.enabled}")
+    private String enableSwagger;
+
     @Bean
-    public Docket api() { 
-        return new Docket(DocumentationType.SWAGGER_2)  
-          .select()                                  
-          .apis(RequestHandlerSelectors.any())              
-          .paths(PathSelectors.any())                          
-          .build();                                           
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build()
+                .enable(Boolean.parseBoolean(enableSwagger));
     }
 }

--- a/src/main/java/apex/ingagers/ecommerce/config/WebMvcConfig.java
+++ b/src/main/java/apex/ingagers/ecommerce/config/WebMvcConfig.java
@@ -1,19 +1,23 @@
 package apex.ingagers.ecommerce.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+
 @Configuration
-public class WebMvcConfig implements WebMvcConfigurer{
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Value("${cors.allowed-api}")
+    private String myAllowedApi;
     
     @Override
-    public void addCorsMappings(CorsRegistry registry){
+    public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedMethods("*")
-            .allowedOrigins("http://localhost:3000")
-            .allowedHeaders("*")
-            .allowCredentials(false)
-            .maxAge(-1);
+                .allowedMethods("*")
+                .allowedOrigins(myAllowedApi)
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(-1);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.driver-class-name=${DB_DRIVER:com.mysql.jdbc.Driver}
 #spring.jpa.show-sql: true
 server.port=${PORT:8080}
 spring.jackson.serialization.fail-on-empty-beans=false
+cors.allowed-api=${ALLOWED_API:http://localhost:3000}
+documentation.enabled=${ENABLE_SWAGGER:true}
+spring.profiles.active=dev


### PR DESCRIPTION
## What?
Enabled the manipulation of the CORS route and deactivation of Swagger on production with an environment variable.

## Why?
So that both the Front and Back can communicate without problems, using CORS and pointing to the correct direction for the API.

## Testing / Proof
How Swagger is disabled.
![image](https://user-images.githubusercontent.com/44516996/145650573-44bbfb63-efbf-4ea3-a1a8-06c01bbc7da8.png)

## How can this change be undone in case of failure?
Go back to previous versions of both WebMvcCofig and SpringFoxConfig.

ping @fullstack-bootcamp-2021
