### PR TITLE
[US-55] Code Coverage Report and Threshold at 0%

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,9 @@ jobs:
             - v1-dependencies-
       - attach_workspace:
           at: ./target
-      - run: ./mvnw test
+      - run: ./mvnw verify
       - store_artifacts:
           path: target
-      - run: ./mvnw verify
   docker-build:
     executor: docker-publisher
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,8 @@ jobs:
       - attach_workspace:
           at: ./target
       - run: ./mvnw test
+      - store_artifacts:
+          path:  target
   docker-build:
     executor: docker-publisher
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
           at: ./target
       - run: ./mvnw test
       - store_artifacts:
-          path:  target
+          path: target
+      - run: ./mvnw verify
   docker-build:
     executor: docker-publisher
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -82,7 +83,7 @@
 	<build>
 		<finalName>app</finalName>
 		<plugins>
-		<plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.3</version>
@@ -111,6 +112,27 @@
 							<dataFile>target/jacoco.exec</dataFile>
 							<!-- Sets the output directory for the code coverage report. -->
 							<outputDirectory>target/my-reports</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>jacoco-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<dataFile>target/jacoco.exec</dataFile>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>INSTRUCTION</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.80</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,44 @@
 	<build>
 		<finalName>app</finalName>
 		<plugins>
+		<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.3</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+							<dataFile>target/jacoco.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>target/my-reports</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<systemPropertyVariables>
+						<jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,21 +53,11 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<!-- <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>3.0.0</version>
-		</dependency>	 -->
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>
 			<version>3.0.0</version>
 		</dependency>
-		<!-- <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
-		</dependency> -->
 		<dependency>
 			<groupId>com.cloudinary</groupId>
 			<artifactId>cloudinary-http44</artifactId>
@@ -110,8 +100,6 @@
 						<configuration>
 							<!-- Sets the path to the file which contains the execution data. -->
 							<dataFile>target/jacoco.exec</dataFile>
-							<!-- Sets the output directory for the code coverage report. -->
-							<outputDirectory>target/my-reports</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -128,7 +116,7 @@
 										<limit>
 											<counter>INSTRUCTION</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.80</minimum>
+											<minimum>0.0</minimum>
 										</limit>
 									</limits>
 								</rule>


### PR DESCRIPTION
## What?
Implementation of Code Coverage in CircleCI by adding JaCoCo to the project and setting a threshold of 0% at the moment, waiting to raise that up to around 70% to 80% in total.

## Why?
To preserve a well-maintained product around all changes that go through by making a way to **report** and **verify** the number of lines covered by unit testing.

## Testing / Proof
After each testing job on CircleCI developers can review Code Coverage reports by entering the job and then selecting the tab of "Artifacts" to finally enter the "target/site/jacoco/index.html" file. 
![image](https://user-images.githubusercontent.com/44516996/147297842-77546254-b507-474b-90c8-7a306bf72fcc.png)

Another way to see the report is to enter the following link: https://263-425176645-gh.circle-artifacts.com/0/target/site/jacoco/index.html and change the first number for the number of the testing job (which, in this case, was 263).

## How can this change be undone in case of failure?
The possible error to be found in the future is that the minimum threshold is not being covered and the addition of new unit tests.

ping @fullstack-bootcamp-2021
