### PR TITLE
[US-47] Default addresses

### DIFF
--- a/src/main/java/apex/ingagers/ecommerce/controller/AddressesController.java
+++ b/src/main/java/apex/ingagers/ecommerce/controller/AddressesController.java
@@ -1,11 +1,9 @@
 package apex.ingagers.ecommerce.controller;
 
 import java.sql.Timestamp;
-import java.util.Map;
 import java.util.Optional;
 import java.util.List;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,37 +30,17 @@ public class AddressesController {
     }
 
     @PostMapping("/addresses") // Map ONLY POST Requests
-    Addresses addAddresses(@RequestBody Map<String, Object> values) {
-        String street1 = String.valueOf(values.get("street1"));
-        String street2 = String.valueOf(values.get("street2"));
-        String colonia = String.valueOf(values.get("colonia"));
-        String municipio = String.valueOf(values.get("municipio"));
-        String state = String.valueOf(values.get("state"));
-        String country = String.valueOf(values.get("country"));
-        String postal_code = String.valueOf(values.get("postal_code"));
-        String phone = String.valueOf(values.get("phone"));
-        String client_name = String.valueOf(values.get("client_name"));
-        int id_user = Integer.parseInt(String.valueOf(values.get("id_user")));
-        // casteo de string
+    Addresses addAddresses(@RequestBody Addresses addresses) {
 
         long now = System.currentTimeMillis();
         Timestamp sqlTimestamp = new Timestamp(now);
 
-        Addresses a = new Addresses();
-        a.setStreet1(street1);
-        a.setStreet2(street2);
-        a.setColonia(colonia);
-        a.setMunicipio(municipio);
-        a.setState(state);
-        a.setCountry(country);
-        a.setPostal_code(postal_code);
-        a.setPhone(phone);
-        a.setClient_name(client_name);
+        Addresses a = addresses;
         a.setCreated_at(sqlTimestamp);
         a.setUpdated_at(null);
         a.setDelete_at(null);
 
-        List<Users> optionalUser = userRepository.findUserById(id_user);
+        List<Users> optionalUser = userRepository.findUserById(a.getUsers().getId());
         if (!optionalUser.isEmpty()) {
             Users users = optionalUser.get(0);
             a.setUsers(users);
@@ -98,28 +76,28 @@ public class AddressesController {
       }
 
     @PutMapping("/addresses/{id}")
-    public Addresses update(@PathVariable("id") Integer id, @RequestBody Map<String, Object> values) {
+    public Addresses update(@PathVariable("id") Integer id, @RequestBody Addresses addresses) {
 
         Optional<Addresses> optionaladdresses = addressesRepository.findById(id);
 
         if (optionaladdresses.isPresent()) {
-            Addresses addresses = optionaladdresses.get();
-            addresses.setStreet1(String.valueOf(values.get("street1")));
-            addresses.setStreet2(String.valueOf(values.get("street2")));
-            addresses.setColonia(String.valueOf(values.get("colonia")));
-            addresses.setMunicipio(String.valueOf(values.get("municipio")));
-            addresses.setState(String.valueOf(values.get("state")));
-            addresses.setCountry(String.valueOf(values.get("country")));
-            addresses.setPostal_code(String.valueOf(values.get("postal_code")));
-            addresses.setPhone(String.valueOf(values.get("phone")));
-            addresses.setClient_name(String.valueOf(values.get("client_name")));
+            Addresses newaddresses = optionaladdresses.get();
+            newaddresses.setStreet1(addresses.getStreet1());
+            newaddresses.setStreet2(addresses.getStreet2());
+            newaddresses.setColonia(addresses.getColonia());
+            newaddresses.setMunicipio(addresses.getMunicipio());
+            newaddresses.setState(addresses.getState());
+            newaddresses.setCountry(addresses.getCountry());
+            newaddresses.setPostal_code(addresses.getPostal_code());
+            newaddresses.setPhone(addresses.getPhone());
+            // newaddresses.setClient_name();
 
             long now = System.currentTimeMillis();
             Timestamp sqlTimestamp = new Timestamp(now);
 
-            addresses.setUpdated_at(sqlTimestamp);
+            newaddresses.setUpdated_at(sqlTimestamp);
 
-            return addresses;
+            return addressesRepository.save(newaddresses);
         }
         return null;
     }

--- a/src/main/java/apex/ingagers/ecommerce/model/Addresses.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/Addresses.java
@@ -32,11 +32,19 @@ public class Addresses {
     private Timestamp created_at;
     private Timestamp updated_at;
     private Timestamp delete_at;
+    // * Default billing and shipping address columns
+    // * Only 1 shipping and 1 billing should be true for each user
+    @Column(columnDefinition = "TINYINT(1)",nullable = false)
+    private boolean default_billing_address;
+    @Column(columnDefinition = "TINYINT(1)",nullable = false)
+    private boolean default_shipping_address;
 
     //Foreign Key id_user
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_user", nullable = false)
     private Users users;
+
+    //----------------- END of Table structure-----------------
 
     public Users getUsers() {
         return this.users;
@@ -45,16 +53,6 @@ public class Addresses {
     public void setUsers(Users users) {
         this.users = users;
     }
-
-    // //FK relation with Orders 
-    // @OneToMany(mappedBy = "billing_address")
-    // List<Orders> billing_address;
-
-    // //FK relation with Orders 
-    // @OneToMany(mappedBy = "shipping_address")x
-    // List<Orders> shipping_address;
-
-    //----------------- END of Table structure-----------------
 
     public Integer getId() {
         return this.id;

--- a/src/main/java/apex/ingagers/ecommerce/model/Addresses.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/Addresses.java
@@ -5,11 +5,21 @@ import java.util.Optional;
 
 import javax.persistence.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.swagger.annotations.ApiModelProperty;
+
 @Entity // This tells Hibernate to make a table out of this class
 public class Addresses {
+
+    // @ApiModelProperty(hidden = true)  --- Para no pedir el dato en swagger pero si devolver en json
+    // @JsonIgnore -- Para no mandar ni mostrar el dato en swagger
+
     @Id
     @GeneratedValue(strategy=GenerationType.IDENTITY)
+    @ApiModelProperty(hidden = true)
     private Integer id;
+    
     @Column(nullable = false)
     private String street1;
     private String street2;
@@ -26,11 +36,17 @@ public class Addresses {
     private String phone;
     @Column(nullable = false)
     private String client_name;
+
     @Column(name = "is_active", columnDefinition = "TINYINT(1) DEFAULT 1",insertable = false,nullable = false)
+    @ApiModelProperty(hidden = true) @JsonIgnore
     private boolean is_active;
+
     @Column(nullable = false)
+    @ApiModelProperty(hidden = true) @JsonIgnore
     private Timestamp created_at;
+    @ApiModelProperty(hidden = true) @JsonIgnore
     private Timestamp updated_at;
+    @ApiModelProperty(hidden = true) @JsonIgnore
     private Timestamp delete_at;
     // * Default billing and shipping address columns
     // * Only 1 shipping and 1 billing should be true for each user

--- a/src/main/java/apex/ingagers/ecommerce/model/OrderProduct.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/OrderProduct.java
@@ -6,9 +6,6 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
 
@@ -33,7 +30,7 @@ public class OrderProduct {
    private int quantity;
    @Column(nullable = false)
    private float price;
-   //? Should this column below exist?
+   // * This column saves the original name of the product at the time of purchase (in case the name is changed later)
    @Column(nullable = false)
    private String name;
    // End of table structure
@@ -52,6 +49,30 @@ public class OrderProduct {
 
    public void setProducts(Products products) {
       this.products = products;
+   }
+
+   public int getQuantity() {
+      return this.quantity;
+   }
+
+   public void setQuantity(int quantity) {
+      this.quantity = quantity;
+   }
+
+   public float getPrice() {
+      return this.price;
+   }
+
+   public void setPrice(float price) {
+      this.price = price;
+   }
+
+   public String getName() {
+      return this.name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
    }
    
    @Embeddable

--- a/src/main/java/apex/ingagers/ecommerce/model/OrderStatusHistory.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/OrderStatusHistory.java
@@ -1,0 +1,97 @@
+package apex.ingagers.ecommerce.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import java.sql.Timestamp;
+
+@Entity // This tells Hibernate to make a table out of this class
+public class OrderStatusHistory {
+   /* 
+   * Primary key is composed of both orders and products with "MapsId"
+   * and set into OrderStatusHistoryId using "EmbeddedId" 
+   */
+   @EmbeddedId
+   private OrderStatusHistoryId id = new OrderStatusHistoryId();
+
+   @ManyToOne
+   @MapsId("id_order")
+   private Orders orders;
+
+   @ManyToOne
+   @MapsId("id_status")
+   private OrderStatuses status;
+
+   private Timestamp created_at;
+   private Timestamp updated_at;
+   // End of table structure
+
+   public Orders getOrders() {
+      return this.orders;
+   }
+
+   public void setOrders(Orders orders) {
+      this.orders = orders;
+   }  
+
+   public OrderStatuses getStatus() {
+      return this.status;
+   }
+
+   public void setStatus(OrderStatuses status) {
+      this.status = status;
+   }
+
+   public Timestamp getCreated_at() {
+      return this.created_at;
+   }
+
+   public void setCreated_at(Timestamp created_at) {
+      this.created_at = created_at;
+   }
+
+   public Timestamp getUpdated_at() {
+      return this.updated_at;
+   }
+
+   public void setUpdated_at(Timestamp updated_at) {
+      this.updated_at = updated_at;
+   }
+
+
+   @Embeddable
+   public static class OrderStatusHistoryId implements Serializable {
+
+      private int id_order;
+      private int id_status;
+
+      public OrderStatusHistoryId() {
+
+      }
+
+      public OrderStatusHistoryId(int id_order, int id_status) {
+         this.id_order = id_order;
+         this.id_status = id_status;
+      }
+
+      public int getId_order() {
+         return this.id_order;
+      }
+
+      public void setId_order(int id_order) {
+         this.id_order = id_order;
+      }
+
+      public int getId_status() {
+         return this.id_status;
+      }
+
+      public void setId_status(int id_status) {
+         this.id_status = id_status;
+      }
+   }
+}

--- a/src/main/java/apex/ingagers/ecommerce/model/OrderStatuses.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/OrderStatuses.java
@@ -1,0 +1,80 @@
+package apex.ingagers.ecommerce.model;
+
+import java.sql.Timestamp;
+
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.swagger.annotations.ApiModelProperty;
+
+
+@Entity // This tells Hibernate to make a table out of this class
+public class OrderStatuses {
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    @ApiModelProperty(hidden = true) 
+    private Integer id;
+    
+    private String status_name;
+    private String description;
+
+    @Column(name = "is_active", columnDefinition = "TINYINT(1) DEFAULT 1",insertable = false)
+    @JsonIgnore @ApiModelProperty(hidden = true) 
+    private boolean is_active;
+
+    @JsonIgnore @ApiModelProperty(hidden = true) 
+    private Timestamp created_at;
+
+    @JsonIgnore @ApiModelProperty(hidden = true) 
+    private Timestamp updated_at;
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getStatus_ename() {
+        return this.status_name;
+    }
+
+    public void setStatus_name(String status_name) {
+        this.status_name = status_name;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean getIs_active() {
+        return this.is_active;
+    }
+
+    public void setIs_active(boolean is_active) {
+        this.is_active = is_active;
+    }
+
+    public Timestamp getCreated_at() {
+        return this.created_at;
+    }
+
+    public void setCreated_at(Timestamp created_at) {
+        this.created_at = created_at;
+    }
+
+    public Timestamp getUpdated_at() {
+        return this.updated_at;
+    }
+
+    public void setUpdated_at(Timestamp updated_at) {
+        this.updated_at = updated_at;
+    }
+
+}

--- a/src/main/java/apex/ingagers/ecommerce/model/Orders.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/Orders.java
@@ -9,7 +9,7 @@ public class Orders {
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Integer id;
     private float total_cost;
-    private int status;
+
     @Column(name="is_active", columnDefinition = "TINYINT(1) DEFAULT 1",insertable = false)
     private boolean  is_active; 
     private Timestamp created_at;
@@ -46,14 +46,6 @@ public class Orders {
 
     public void setTotal_cost(float total_cost) {
         this.total_cost = total_cost;
-    }
-
-    public int getStatus() {
-        return this.status;
-    }
-
-    public void setStatus(int status) {
-        this.status = status;
     }
 
     public boolean getIs_active() {

--- a/src/main/java/apex/ingagers/ecommerce/model/Users.java
+++ b/src/main/java/apex/ingagers/ecommerce/model/Users.java
@@ -13,7 +13,6 @@ public class Users {
   
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @ApiModelProperty(hidden = true) 
   private Integer id;
 
   @Column(nullable = false)

--- a/src/main/java/apex/ingagers/ecommerce/repository/OrderStatusHistoryRepository.java
+++ b/src/main/java/apex/ingagers/ecommerce/repository/OrderStatusHistoryRepository.java
@@ -1,0 +1,7 @@
+package apex.ingagers.ecommerce.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import apex.ingagers.ecommerce.model.OrderStatusHistory;
+
+public interface OrderStatusHistoryRepository extends JpaRepository<OrderStatusHistory, Integer> {}

--- a/src/main/java/apex/ingagers/ecommerce/repository/OrderStatusesRepository.java
+++ b/src/main/java/apex/ingagers/ecommerce/repository/OrderStatusesRepository.java
@@ -3,5 +3,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import apex.ingagers.ecommerce.model.OrderStatuses;
 
 public interface OrderStatusesRepository extends JpaRepository<OrderStatuses, Integer> {
-   OrderStatuses findByStatusName(String status_name);
 }

--- a/src/main/java/apex/ingagers/ecommerce/repository/OrderStatusesRepository.java
+++ b/src/main/java/apex/ingagers/ecommerce/repository/OrderStatusesRepository.java
@@ -1,0 +1,7 @@
+package apex.ingagers.ecommerce.repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import apex.ingagers.ecommerce.model.OrderStatuses;
+
+public interface OrderStatusesRepository extends JpaRepository<OrderStatuses, Integer> {
+   OrderStatuses findByStatusName(String status_name);
+}


### PR DESCRIPTION
## What?
Modified addresses table so it has two new columns: default_billing & default_shipping. These 2 new columns will keep record of the default addresses of each user.

Added OrderStatus and OrderStatusHistory tables.

## Why?
Changes needed so the shopper can have default addresses.
On the orders side, these new tables will help to track the order history.

## Testing / Proof
![image](https://user-images.githubusercontent.com/50469007/149195293-0d983002-ec1c-4a2f-aa3e-eb022f9f2a9c.png)
![image](https://user-images.githubusercontent.com/50469007/149195325-b1297703-bd23-494b-9e51-cfd524e5ce4c.png)
![image](https://user-images.githubusercontent.com/50469007/149195377-2f28e8cc-3d47-419d-baac-d17620411750.png)

## How can this change be undone in case of failure?
Delete two new model tables. 
For the Addresses columns, it's just necessary to delete the column declaration as well as setters and getters.

ping @fullstack-bootcamp-2021
